### PR TITLE
Output only 1 channel to feed to the FC layer.

### DIFF
--- a/conv_model.py
+++ b/conv_model.py
@@ -19,7 +19,7 @@ class Net(nn.Module):
         self.cv1 = nn.Conv1d(1, 20, kernel_size)
         self.mx1 = nn.MaxPool1d(max_pool_1_size)
 
-        self.cv2 = nn.Conv1d(20, 20, kernel_size)
+        self.cv2 = nn.Conv1d(20, 1, kernel_size)
         self.mx2 = nn.MaxPool1d(max_pool_1_size)
         # self.cv2 = nn.Conv1d(1, 20, kernel_size)
         # self.mx1 = nn.MaxPool1d(max_pool_1_size)


### PR DESCRIPTION
Currently, the cv2/mx2 layer outputs 20 channels. However, the
seubseqent FC layer fc2 expects only one channel of input.  Therefore,
we need to change the number of filters in cv2 to 1.