### PR TITLE
Use reLU() activation function for the output layer.

### DIFF
--- a/conv_all_model.py
+++ b/conv_all_model.py
@@ -36,7 +36,7 @@ class Net(nn.Module):
         x = self.cv2(x)
         x = self.mx2(x)
         x = torch.tanh(self.fc2(x))
-        x = torch.tanh(self.fc3(x))
+        x = torch.relu(self.fc3(x))
         return x
 
     def num_flat_features(self, x):

--- a/conv_model.py
+++ b/conv_model.py
@@ -36,7 +36,7 @@ class Net(nn.Module):
         x = self.cv2(x)
         x = self.mx2(x)
         x = torch.tanh(self.fc2(x))
-        x = torch.tanh(self.fc3(x))
+        x = torch.relu(self.fc3(x))
         return x
 
     def num_flat_features(self, x):

--- a/model.py
+++ b/model.py
@@ -20,7 +20,7 @@ class Net(nn.Module):
         # return torch.tanh(self.fc1(x))
         x = torch.tanh(self.fc1(x))
         x = torch.tanh(self.fc2(x))
-        x = torch.tanh(self.fc3(x))
+        x = torch.relu(self.fc3(x))
         return x
 
     def num_flat_features(self, x):


### PR DESCRIPTION
The predicted output is ratio of pirces. Therefore, it will be in the
vicinity of 1. However, tanh() varies between -1 and 1, so it does not
model the output correctly.